### PR TITLE
helpop: Add JOIN notifications and autoop for help chan

### DIFF
--- a/files/helpop.c
+++ b/files/helpop.c
@@ -49,7 +49,7 @@ CMD_FUNC(REPORT);
 
 
 ModuleHeader MOD_HEADER = {
-	"third/helpop", // Module name
+	"third/helpop2", // Module name
 	"1.4", // Module Version
 	"HelpOp - Provides usermode h (HelpOp) and swhois line, channelmode g (HelpOp-only room), and command /HELPOPS", // Description
 	"Valware", // Author
@@ -171,7 +171,8 @@ int helpchan_join_op_presence_check(Client *client, Channel *channel, MessageTag
 	for (member = channel->members; member; member = member->next)
 	{
 		Membership *mb = find_membership_link(member->client->user->channel, channel);
-		if (IsHelpop(member->client) && client == member->client)
+
+		if (IsHelpop(member->client) && client == member->client && client->local)
 		{
 			MessageTag *mtags = NULL;
 	

--- a/files/helpop.c
+++ b/files/helpop.c
@@ -176,7 +176,7 @@ int helpchan_join_op_presence_check(Client *client, Channel *channel, MessageTag
 			MessageTag *mtags = NULL;
 	
 			new_message(member->client, NULL, &mtags);
-			sendto_channel(channel, &me, NULL, 0, 0, SEND_ALL, mtags,
+			sendto_channel(channel, &me, NULL, 0, 0, SEND_LOCAL, mtags,
 						":%s MODE %s %s %s",
 						me.name, channel->name, "+o", client->name);
 			sendto_server(NULL, 0, 0, mtags, ":%s MODE %s %s %s%s", me.id, channel->name, "+o", client->name, IsServer(member->client)?" 0":"");

--- a/files/helpop.c
+++ b/files/helpop.c
@@ -77,6 +77,7 @@ MOD_INIT() {
 	
 	HookAdd(modinfo->handle, HOOKTYPE_WHOIS, 0, helpop_whois);
 	HookAdd(modinfo->handle, HOOKTYPE_LOCAL_JOIN, 0, helpchan_join_op_presence_check);
+	HookAdd(modinfo->handle, HOOKTYPE_REMOTE_JOIN, 0, helpchan_join_op_presence_check);
 
 	MARK_AS_GLOBAL_MODULE(modinfo);
 	return MOD_SUCCESS;

--- a/files/helpop.c
+++ b/files/helpop.c
@@ -49,7 +49,7 @@ CMD_FUNC(REPORT);
 
 
 ModuleHeader MOD_HEADER = {
-	"third/helpop2", // Module name
+	"third/helpop", // Module name
 	"1.4", // Module Version
 	"HelpOp - Provides usermode h (HelpOp) and swhois line, channelmode g (HelpOp-only room), and command /HELPOPS", // Description
 	"Valware", // Author


### PR DESCRIPTION
If someone joins the config-defined help channel and there are no ops (and the person joining was not a helpop) then the helpops will get a server notice letting them know someone joined the channel.
If a helpop joins the config-defined help channel they will be automatically opped.
