### PR TITLE
Updated qline.c copyright notice.

### DIFF
--- a/files/qline.c
+++ b/files/qline.c
@@ -9,7 +9,7 @@
 * -----------------------------------------------------------------------------------------------------------------------------------------------
 * MIT License
 *
-* Copyright (c) 2022 Avery 'Hexick' Q. [pseudonym]
+* Copyright (c) 2023 Avery 'Hexick' Q. [pseudonym]
 *
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Changed the MIT copyright license to the current year on the qline.c file.