### PR TITLE
fix: Remove redundant NULL check on username array in autovhost module

### DIFF
--- a/files/autovhost.c
+++ b/files/autovhost.c
@@ -267,7 +267,7 @@ int autovhost_connect(Client *client) {
 		}
 
 		if(strstr(newhost, "$ident")) {
-			newhost_ident = replaceem(newhost, "$ident", (client->user->username ? client->user->username : "unknown"));
+			newhost_ident = replaceem(newhost, "$ident", client->user->username);
 			snprintf(newhost, sizeof(newhost), "%s", newhost_ident);
 			safe_free(newhost_ident);
 		}


### PR DESCRIPTION
## Description

This pull request fixes a compiler warning in the `autovhost.c` module that was causing noise during the build process. The warning occurred because of an unnecessary NULL check on the `client->user->username` field, which is declared as a character array (`char username[USERLEN + 1]`) and therefore can never be NULL.

## What was changed

Modified line 270 in `autovhost.c` from:
```c
newhost_ident = replaceem(newhost, "$ident", (client->user->username ? client->user->username : "unknown"));
```

To:
```c
newhost_ident = replaceem(newhost, "$ident", client->user->username);
```

## Why this change is necessary

The compiler was generating the following warning:
```
autovhost.c: In function 'autovhost_connect':
autovhost.c:270:94: warning: the comparison will always evaluate as 'true' for the address of 'username' will never be NULL [-Waddress]
  270 |     newhost_ident = replaceem(newhost, "$ident", (client->user->username ? client->user->username : "unknown"));
      |                                                                                              ^
In file included from /home/creole/_downloads/unrealircd-6.1.10/include/unrealircd.h:7,
                 from autovhost.c:24:
/home/creole/_downloads/unrealircd-6.1.10/include/struct.h:1533:14: note: 'username' declared here
 1533 |         char username[USERLEN + 1];     /**< Username, the user portion in nick!user@host. */
      |              ^~~~~~~~
```

This warning occurs because `client->user->username` is defined as a character array in `struct.h`, not as a pointer. Arrays in C are fixed memory locations and their addresses can never be NULL, making the conditional check `client->user->username ? client->user->username : "unknown"` redundant and triggering the compiler warning.

## Technical details

In C, when an array is declared (like `char username[USERLEN + 1]`), the array name (`username`) is essentially a constant pointer to the first element of the array. This address is allocated at compile time or on the stack, and cannot be NULL. Therefore, checking if such an array name is NULL is pointless, as pointed out by the compiler warning.

When `replaceem()` is called, it only needs the address of the array, which is always valid. The ternary operator was unnecessary and caused the warning.

## Testing performed

The module was recompiled after the change, and the compiler warning was eliminated. The functionality remains identical because:

1. The condition `client->user->username ? client->user->username : "unknown"` would always evaluate to `client->user->username` anyway
2. The presence check for `client` and `client->user` is already done earlier in the function (line 261)
3. The module continues to correctly substitute the `$ident` variable in vhost templates

This change improves code quality by removing redundant checks and eliminating compiler warnings, making the codebase cleaner and more maintainable.

## Additional notes

While this change may seem minor, keeping the codebase free of compiler warnings is important as it:
- Makes legitimate warnings more visible
- Improves maintainability of the code
- Prevents potential future issues that might arise from misunderstanding the behavior
- Aligns with best practices for C programming

IMPORTANT!!

DO NOT file a PR for modules that are not yours!
You should contact the 3rd party module author/maintainer instead.

The UnrealIRCd team only accepts changes from the module maintainer.
We cannot judge PR's on the maintainer's behalf. All changes,
small or big, must come from the module maintainer to maintain
a clear division of responsibilities. 

Only file a PR if:
* You are the maintainer of the existing module, OR
* You are submitting a new module and have read
  https://www.unrealircd.org/docs/Rules_for_3rd_party_modules_in_unrealircd-contrib

Thanks!
