### PR TITLE
relaymsg: store relayed messages in +H history

### DIFF
--- a/files/relaymsg.c
+++ b/files/relaymsg.c
@@ -39,6 +39,7 @@ const char *relay_msg_cap_parameter(Client *client);
 
 CMD_FUNC(cmd_relaymsg);
 CMD_FUNC(cmd_rrelaymsg);
+static void relay_to_channel(Channel *channel, MessageTag *mtags, const char *nick, const char *text);
 
 struct MyConfStruct
 {
@@ -230,6 +231,19 @@ const char *relay_msg_cap_parameter(Client *client)
 }
 
 // Command to send a message to a channel as a spoofed nick
+/* Deliver a relayed message to the channel under the spoofed nick, and record
+ * it in +H history -- sendto_channel() bypasses the CHANMSG hook that normally
+ * feeds history, so without this relayed lines never show up in CHATHISTORY. */
+static void relay_to_channel(Channel *channel, MessageTag *mtags, const char *nick, const char *text)
+{
+	char line[512];
+
+	ircsnprintf(line, sizeof(line), ":%s!%s PRIVMSG %s :%s", nick, MyConf.hostmask, channel->name, text);
+	sendto_channel(channel, &me, NULL, NULL, 0, SEND_LOCAL, mtags, "%s", line);
+	if (has_channel_mode(channel, 'H'))
+		history_add(channel->name, mtags, line);
+}
+
 CMD_FUNC(cmd_relaymsg)
 {
 	MessageTag *mtags = NULL, *m = NULL;
@@ -290,17 +304,7 @@ CMD_FUNC(cmd_relaymsg)
 	new_message(client, recv_mtags, &mtags);
 
 
-	sendto_channel(channel, &me, NULL, NULL, 0, SEND_LOCAL, mtags,
-						":%s!%s PRIVMSG %s :%s", parv[2], MyConf.hostmask, parv[1], parv[3]);
-	/* sendto_channel() delivers straight to members and skips the CHANMSG
-	 * history hook, so relayed lines never reach +H storage -- record them
-	 * here ourselves or they are absent from CHATHISTORY playback. */
-	if (has_channel_mode(channel, 'H'))
-	{
-		char histbuf[512];
-		ircsnprintf(histbuf, sizeof(histbuf), ":%s!%s PRIVMSG %s :%s", parv[2], MyConf.hostmask, parv[1], parv[3]);
-		history_add(channel->name, mtags, histbuf);
-	}
+	relay_to_channel(channel, mtags, parv[2], parv[3]);
 	sendto_server(NULL, 0, 0, mtags,
 						 ":%s RRELAYMSG %s %s %s :%s", me.name, client->id, parv[1], parv[2], parv[3]);
 }
@@ -324,14 +328,7 @@ CMD_FUNC(cmd_rrelaymsg)
 	if (!channel)
 		return;
 	
-	sendto_channel(channel, &me, NULL, NULL, 0, SEND_LOCAL, recv_mtags,
-				 ":%s!%s PRIVMSG %s :%s", parv[2], MyConf.hostmask, parv[3], parv[4]);
-	if (has_channel_mode(channel, 'H'))
-	{
-		char histbuf[512];
-		ircsnprintf(histbuf, sizeof(histbuf), ":%s!%s PRIVMSG %s :%s", parv[2], MyConf.hostmask, parv[3], parv[4]);
-		history_add(channel->name, recv_mtags, histbuf);
-	}
+	relay_to_channel(channel, recv_mtags, parv[3], parv[4]);
 	sendto_server(client, 0, 0, recv_mtags,
 				 ":%s RRELAYMSG %s %s %s :%s", me.name, parv[1], parv[2], parv[3], parv[4]);
 }

--- a/files/relaymsg.c
+++ b/files/relaymsg.c
@@ -292,6 +292,15 @@ CMD_FUNC(cmd_relaymsg)
 
 	sendto_channel(channel, &me, NULL, NULL, 0, SEND_LOCAL, mtags,
 						":%s!%s PRIVMSG %s :%s", parv[2], MyConf.hostmask, parv[1], parv[3]);
+	/* sendto_channel() delivers straight to members and skips the CHANMSG
+	 * history hook, so relayed lines never reach +H storage -- record them
+	 * here ourselves or they are absent from CHATHISTORY playback. */
+	if (has_channel_mode(channel, 'H'))
+	{
+		char histbuf[512];
+		ircsnprintf(histbuf, sizeof(histbuf), ":%s!%s PRIVMSG %s :%s", parv[2], MyConf.hostmask, parv[1], parv[3]);
+		history_add(channel->name, mtags, histbuf);
+	}
 	sendto_server(NULL, 0, 0, mtags,
 						 ":%s RRELAYMSG %s %s %s :%s", me.name, client->id, parv[1], parv[2], parv[3]);
 }
@@ -317,6 +326,12 @@ CMD_FUNC(cmd_rrelaymsg)
 	
 	sendto_channel(channel, &me, NULL, NULL, 0, SEND_LOCAL, recv_mtags,
 				 ":%s!%s PRIVMSG %s :%s", parv[2], MyConf.hostmask, parv[3], parv[4]);
+	if (has_channel_mode(channel, 'H'))
+	{
+		char histbuf[512];
+		ircsnprintf(histbuf, sizeof(histbuf), ":%s!%s PRIVMSG %s :%s", parv[2], MyConf.hostmask, parv[3], parv[4]);
+		history_add(channel->name, recv_mtags, histbuf);
+	}
 	sendto_server(client, 0, 0, recv_mtags,
 				 ":%s RRELAYMSG %s %s %s :%s", me.name, parv[1], parv[2], parv[3], parv[4]);
 }


### PR DESCRIPTION
`RELAYMSG` delivers messages with `sendto_channel()`, which skips the `HOOKTYPE_CHANMSG` hook that the history module uses to record into `+H` channel history. So relayed (bridge) messages were never stored — they're missing from `CHATHISTORY` playback and on-join history, while normal messages show up fine.

This records the relayed line into history ourselves when the channel has `+H` (gated so it never hits the no-limit path on non-history channels), for both the local `RELAYMSG` and the server-to-server `RRELAYMSG` paths. The `draft/relaymsg` tag is carried through so clients still render it as a relay on playback.